### PR TITLE
feat: Add CPU frequency check from sysfs

### DIFF
--- a/spec_sniffer.sh
+++ b/spec_sniffer.sh
@@ -39,6 +39,25 @@ print_header "CPU Information"
 # lscpu provides a detailed and well-formatted summary
 lscpu
 
+# Attempt to read CPU frequency from sysfs, which is often more reliable
+# in virtualized environments or on certain architectures (e.g., ARM).
+FREQ_MAX_FILE="/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq"
+FREQ_CUR_FILE="/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq"
+
+if [ -r "$FREQ_MAX_FILE" ]; then
+    echo -e "\n${C_YELLOW}CPU Frequency (from sysfs):${C_RESET}"
+    # Read value in KHz and convert to MHz for readability
+    max_freq_khz=$(cat "$FREQ_MAX_FILE")
+    max_freq_mhz=$((max_freq_khz / 1000))
+    echo "Max Scaling Frequency   : ${max_freq_mhz} MHz"
+
+    if [ -r "$FREQ_CUR_FILE" ]; then
+        cur_freq_khz=$(cat "$FREQ_CUR_FILE")
+        cur_freq_mhz=$((cur_freq_khz / 1000))
+        echo "Current Scaling Frequency: ${cur_freq_mhz} MHz"
+    fi
+fi
+
 print_header "Memory (RAM) Usage"
 # -h flag makes it human-readable (e.g., GiB, MiB)
 free -h


### PR DESCRIPTION
The script now attempts to read CPU frequency information directly from the /sys filesystem.

This provides a more reliable way to get frequency data, especially on architectures like ARM where 'lscpu' may not report it.

The script checks for scaling_max_freq and scaling_cur_freq and converts the output to MHz for readability.